### PR TITLE
Retry on timeout in RenotifyAll().

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -516,8 +516,14 @@ func (st *storage) RenotifyAll() error {
 
 	q := c.Find(nil).Select(bson.D{{"md5", 1}})
 	iter := q.Iter()
-	for iter.Next(&result) {
-		st.Notify(hkpstorage.KeyAdded{Digest: result.MD5})
+	for {
+		if iter.Next(&result) {
+			st.Notify(hkpstorage.KeyAdded{Digest: result.MD5})
+		} else if iter.Timeout() {
+			continue
+		} else {
+			break
+		}
 	}
 	err := iter.Close()
 	if err != nil {

--- a/storage.go
+++ b/storage.go
@@ -514,20 +514,32 @@ func (st *storage) RenotifyAll() error {
 		MD5 string `bson:"md5"`
 	}
 
-	q := c.Find(nil).Select(bson.D{{"md5", 1}})
-	iter := q.Iter()
+	var lastMD5 string
 	for {
-		if iter.Next(&result) {
-			st.Notify(hkpstorage.KeyAdded{Digest: result.MD5})
-		} else if iter.Timeout() {
+		var where bson.D
+		if lastMD5 != "" {
+			where = bson.D{{"md5", bson.D{{"$gt", lastMD5}}}}
+		}
+		q := c.Find(where).Select(bson.D{{"md5", 1}}).Sort("md5")
+		iter := q.Iter()
+		for {
+			if iter.Next(&result) {
+				st.Notify(hkpstorage.KeyAdded{Digest: result.MD5})
+				lastMD5 = result.MD5
+			} else if iter.Timeout() {
+				continue
+			} else {
+				break
+			}
+		}
+		err := iter.Close()
+		if err == mgo.ErrCursor {
 			continue
+		} else if err != nil {
+			return errgo.Mask(err)
 		} else {
 			break
 		}
-	}
-	err := iter.Close()
-	if err != nil {
-		return errgo.Mask(err)
 	}
 	return nil
 }


### PR DESCRIPTION
Ran into this when attempting a pbuild on a fully-loaded hockeypuck:

```
INFO[15052] 1815000 keys added                           
INFO[15098] 1820000 keys added                           
INFO[15143] 1825000 keys added                           
INFO[15188] 1830000 keys added                           
INFO[15234] 1835000 keys added                           
[{/build/buildd/hockeypuck-2.0~b2~1430780298+4b653e1~trusty/src/github.com/hockeypuck/server/cmd/hockeypuck-pbuild/main.go:103: } {/build/buildd/hockeypuck-2.0~b2~1430780298+4b653e1~trusty/src/gopkg.in/hockeypuck/mgohkp.v1/storage.go:524: } {invalid cursor}]
```

Handling timeouts should help, retrying though.
